### PR TITLE
Decode item to string from utf-8 array

### DIFF
--- a/birdy/twitter.py
+++ b/birdy/twitter.py
@@ -111,7 +111,7 @@ class StreamResponse(BaseResponse):
         for item in self._stream_iter():
             if item:
                 try:
-                    data = json.loads(item, object_hook=self._json_object_hook)
+                    data = json.loads(item.decode('utf-8'), object_hook=self._json_object_hook)
                 except:
                     pass
                 else:


### PR DESCRIPTION
This resolved the issue with stream not returning data.

iter_lines returns utf-8 encoded byte arrays which json.loads throws an exception on.
