### PR TITLE
Updated setup.py for python2 install error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 from birdy import __author__, __version__
 import os
 import sys
+from io import open
 
 try:
     from pypandoc import convert


### PR DESCRIPTION
Collecting birdy
  Downloading birdy-0.3.1.tar.gz
    Complete output from command python setup.py egg_info:
    warning: pypandoc module not found, could not convert Markdown to RST
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/tmp/pip-build-tEUbg6/birdy/setup.py", line 41, in <module>
        long_description = read_md('README.md'),
      File "/private/tmp/pip-build-tEUbg6/birdy/setup.py", line 14, in read_md
        return open(f, 'r', encoding='utf-8').read()
    TypeError: 'encoding' is an invalid keyword argument for this function