### PR TITLE
Use new method to avoid deprecation warning of pypandoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ from setuptools import setup, find_packages
 from birdy import __author__, __version__
 
 try:
-    from pypandoc import convert
+    from pypandoc import convert_file
     def read_md(f):
-        return convert(f, 'rst')
+        return convert_file(f, 'rst')
 except ImportError:
     print("warning: pypandoc module not found, could not convert Markdown to RST")
     def read_md(f):


### PR DESCRIPTION
`DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated. Use 'convert_file()'  or 'convert_text()'.`